### PR TITLE
feat: Prueba de que he creado una rama yo solito

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Install Playwright browsers
         run: pnpm exec playwright install --with-deps
 
-      - name: Run unit tests (Vitest)
+      - name: Run Vitest
         run: pnpm vitest --run
         env:
           SUPABASE_URL: ${{ secrets.SUPABASE_URL }}

--- a/app/tests/frontend/e2e/app.spec.ts
+++ b/app/tests/frontend/e2e/app.spec.ts
@@ -12,11 +12,11 @@ test.describe('Tamborrada Data E2E - Navegación Completa', () => {
 
     // Verificar que estamos en home y el componente ExploreStatistics está presente
     await expect(page.getByRole('heading', { name: /Explora las Estadísticas/i })).toBeVisible();
-    const globalButton = page.locator('text=Global').first();
-    await expect(globalButton).toBeVisible();
 
-    // 2. Navegar a estadísticas globales usando el botón del ExploreStatistics
-    await globalButton.click();
+    // 2. Navegar a estadísticas globales usando el link del ExploreStatistics
+    const globalLink = page.locator('a[href="/statistics/global"]').first();
+    await expect(globalLink).toBeVisible();
+    await globalLink.click();
     await page.waitForLoadState('networkidle');
 
     // Verificar que estamos en la página de estadísticas globales
@@ -109,11 +109,11 @@ test.describe('Tamborrada Data E2E - Navegación Completa', () => {
     }
 
     // 8. Volver a Global usando el header
-    const globalLink = page
+    const globalHeaderLink = page
       .locator('header nav a')
       .filter({ hasText: /Global/i })
       .first();
-    await globalLink.click();
+    await globalHeaderLink.click();
     await page.waitForLoadState('networkidle');
     await expect(page).toHaveURL(/\/statistics\/global/);
     await expect(
@@ -194,8 +194,9 @@ test.describe('Tamborrada Data E2E - Navegación Completa', () => {
       await expect(yearHeading).toBeVisible();
 
       // Capturar screenshot
-      await page.screenshot({ path: `app/tests/frontend/e2e/screenshots/10-navegacion-year-${i + 1}.png` });
+      await page.screenshot({
+        path: `app/tests/frontend/e2e/screenshots/10-navegacion-year-${i + 1}.png`,
+      });
     }
   });
 });
-


### PR DESCRIPTION
This pull request focuses on improving the end-to-end navigation tests in `app.spec.ts` and making minor workflow and formatting adjustments. The main changes enhance test reliability by switching navigation from button clicks to explicit link clicks, clarify test code, and update workflow step names.

**Test improvements:**

* Changed navigation in the E2E test from clicking a "Global" button to clicking a direct link (`a[href="/statistics/global"]`) for more robust and explicit navigation.
* Updated navigation back to the global statistics page to use a more descriptive variable name (`globalHeaderLink`) and clarified the selector for the header navigation link.

**Workflow and formatting updates:**

* Renamed the workflow step from "Run unit tests (Vitest)" to "Run Vitest" for conciseness in `.github/workflows/tests.yml`.
* Improved screenshot code formatting for readability in the E2E test loop.