### PR TITLE
fix: Problema con el sitemap arreglado

### DIFF
--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -2,7 +2,7 @@ import { MetadataRoute } from 'next';
 import { fetchYears } from './(frontend)/services/fetchYears';
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
-  const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || '';
+  const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || 'https://tamborradata.com';
   const currentYear = new Date().getFullYear();
 
   const years = await fetchYears(`${baseUrl}/api/available-years`);


### PR DESCRIPTION
El sitemap necesitaba obtener los años disponibles desde `/api/available-years`, pero estaba usando `process.env.NEXT_PUBLIC_BASE_URL` que en producción no existía o venía vacío.
Como resultado, el fetch se hacía contra una URL incorrecta y no se generaban las entradas del sitemap para los años.

Se ha añadido un fallback a:

```
https://tamborradata.com
```

De modo que el fetch siempre se realice contra la API en producción.
Ahora el sitemap genera correctamente las URLs de cada año.