### PR TITLE
fix: Problema con el sitemap arreglado

### DIFF
--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,14 +1,14 @@
 import { MetadataRoute } from 'next';
-import { fetchYears } from './(frontend)/services/fetchYears';
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const baseUrl = 'https://tamborradata.com';
   const currentYear = new Date().getFullYear();
 
-  const years = await fetchYears(`${baseUrl}/api/available-years`);
-
   const yearUrls = [];
-  for (const year of years?.filter((y) => y !== 'global').map((y) => Number(y)) || []) {
+
+  for (let i = 0; i <= currentYear - 2018; i++) {
+    const year = 2018 + i;
+    if (year === 2021) continue; // 2021 no tiene datos disponibles
     yearUrls.push({
       url: `${baseUrl}/statistics/${year}`,
       lastModified: year === currentYear ? new Date() : new Date(`${year}-01-20`),


### PR DESCRIPTION
Este pull request simplifica la lógica para generar las URLs basadas en años en el `sitemap`, eliminando la dependencia de la obtención dinámica de años y sustituyéndola por un rango predefinido. Ahora, los años se generan desde 2018 hasta el año actual, omitiendo explícitamente 2021 por falta de datos.

Actualización en la generación del sitemap:

* Se elimina el uso de `fetchYears` y la obtención dinámica de años, sustituyéndolo por un rango fijo entre 2018 y el año actual, lo que mejora la fiabilidad y el rendimiento.
* Se omite explícitamente el año 2021 durante la generación de URLs, ya que no se dispone de datos para ese año.