### PR TITLE
fix(global): corregir fetch de commonNameBySchool al paginar

### DIFF
--- a/app/(frontend)/statistics/global/components/CommonNameBySchool/hooks/useCommonNameBySchool.ts
+++ b/app/(frontend)/statistics/global/components/CommonNameBySchool/hooks/useCommonNameBySchool.ts
@@ -8,7 +8,7 @@ import { useTable } from '../../../hooks/useTable';
 export function useCommonNameBySchool() {
   const { stats } = useGlobal();
   const { categoryData, isLoading, refetch } = useCategory<CommonNameBySchoolData>(
-    stats?.mostConstantSchools[0].category || '',
+    stats?.commonNameBySchool[0].category || '',
     GLOBAL_STATS_KEY,
     false
   );


### PR DESCRIPTION
Este PR corrige el comportamiento del botón **“Mostrar más”** en la sección `commonNameBySchool` de la página **Global**.

**Problema**
Al paginar, el componente/hook estaba realizando el fetch usando la categoría/datos de `mostConstantSchools` en lugar de `commonNameBySchool`. Como la respuesta no devolvía el mismo objeto, la UI fallaba y no se renderizaban los datos.

**Solución**
Se actualiza el hook para que, al cargar más resultados, utilice la fuente/categoría correcta: `stats.commonNameBySchool` (en vez de `stats.mostConstantSchools`).

**Resultado**
La paginación vuelve a funcionar correctamente y los datos se cargan sin romperse.